### PR TITLE
Switch to solc 0.8.24, upgrade dependencies and enable via-ir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
       - name: run Slither
         uses: crytic/slither-action@v0.3.0
         with:
-          slither-version: '0.9.5'
+          slither-version: '0.10.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: echo FOUNDRY_FUZZ_RUNS=50000 >> $GITHUB_ENV
       - name: run tests
-        run: forge test --deny-warnings
+        run: FOUNDRY_PROFILE=optimized forge test --deny-warnings
       - name: run Slither
         uses: crytic/slither-action@v0.3.0
         with:

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,9 +1,13 @@
 [profile.default]
 solc_version = '0.8.24'
 evm_version = 'shanghai'
-optimizer_runs = 7_700
+optimizer = false
 verbosity = 1
 fuzz_runs = 5
+[profile.optimized]
+via_ir = true
+optimizer = true
+optimizer_runs = 1_000_000_000
 [fmt]
 line_length = 100
 [fuzz]

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = '0.8.20'
+solc_version = '0.8.24'
 evm_version = 'shanghai'
 optimizer_runs = 7_700
 verbosity = 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -85,7 +85,7 @@ ffffffffffffffffffffffffffe0908116603f0116810190838211818310171561059b5761059b61
 }
 
 drips_deployer() {
-    local GET_DEPLOYED="getDeployed(address deployer, bytes32 salt)(address deployed))"
+    local GET_DEPLOYED="getDeployed(address deployer, bytes32 salt)(address deployed)"
     local SALT="$(cast format-bytes32-string "$DRIPS_DEPLOYER_SALT")"
     cast call "$CREATE3_FACTORY" "$GET_DEPLOYED" "$WALLET" "$SALT"
 }
@@ -197,6 +197,8 @@ query() {
 }
 
 main() {
+    export FOUNDRY_PROFILE=optimized
+
     verify_parameter ETH_RPC_URL
     verify_parameter WALLET_ARGS
     verify_parameter DRIPS_DEPLOYER_SALT
@@ -278,8 +280,8 @@ main() {
         esac
     done
 
-    print_title "Installing dependencies"
-    forge install
+    print_title "Building the contracts"
+    forge build --skip test
 
     if [ -n "$DEPLOY_DETERMINISTIC_DEPLOYER" ]; then
         deploy_deterministic_deployer

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -79,6 +79,8 @@ verify_single() {
 }
 
 main() {
+    export FOUNDRY_PROFILE=optimized
+
     if [ -z "$1" ]; then
         echo "Error: expected 1 argument, the DripsDeployer address, see README.md"
         exit 1

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,4 @@
 {
-    "filter_paths": "(lib/|test/)",
+    "filter_paths": "(lib/)",
     "detectors_to_exclude": "solc-version"
 }

--- a/src/AddressDriver.sol
+++ b/src/AddressDriver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {AccountMetadata, Drips, StreamReceiver, IERC20, SplitsReceiver} from "./Drips.sol";
 import {Managed} from "./Managed.sol";

--- a/src/Caller.sol
+++ b/src/Caller.sol
@@ -86,7 +86,6 @@ contract Caller is EIP712("Caller", "1"), ERC2771Context(address(this)) {
     bytes32 internal immutable callSignedTypeHash = keccak256(bytes(CALL_SIGNED_TYPE_NAME));
 
     /// @notice Each sender's set of address authorized to make calls on its behalf.
-    // slither-disable-next-line naming-convention
     mapping(address sender => AddressSetClearable) internal _authorized;
     /// @notice The nonce which needs to be used in the next EIP-712 message signed by the address.
     mapping(address sender => uint256) public nonce;

--- a/src/Caller.sol
+++ b/src/Caller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Address} from "openzeppelin-contracts/utils/Address.sol";
 import {ECDSA, EIP712} from "openzeppelin-contracts/utils/cryptography/EIP712.sol";

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {
     Streams, StreamConfig, StreamsHistory, StreamConfigImpl, StreamReceiver

--- a/src/DripsDeployer.sol
+++ b/src/DripsDeployer.sol
@@ -18,7 +18,6 @@ struct Module {
 }
 
 contract DripsDeployer is Ownable2Step {
-    // slither-disable-next-line naming-convention
     bytes32[] internal _moduleSalts;
     address public immutable initialOwner;
 
@@ -133,7 +132,6 @@ abstract contract ProxyDeployerModule is BaseModule {
 }
 
 abstract contract DripsDependentModule is BaseModule {
-    // slither-disable-next-line naming-convention
     bytes32 internal immutable _dripsModuleSalt = "Drips";
 
     function _dripsModule() internal view returns (DripsModule) {
@@ -181,7 +179,6 @@ contract DripsModule is DripsDependentModule, ProxyDeployerModule {
 }
 
 abstract contract CallerDependentModule is BaseModule {
-    // slither-disable-next-line naming-convention
     bytes32 internal immutable _callerModuleSalt = "Caller";
 
     function _callerModule() internal view returns (CallerModule) {

--- a/src/DripsDeployer.sol
+++ b/src/DripsDeployer.sol
@@ -132,10 +132,10 @@ abstract contract ProxyDeployerModule is BaseModule {
 }
 
 abstract contract DripsDependentModule is BaseModule {
-    bytes32 internal immutable _dripsModuleSalt = "Drips";
+    bytes32 internal constant _DRIPS_MODULE_SALT = "Drips";
 
     function _dripsModule() internal view returns (DripsModule) {
-        address module = _moduleAddress(_dripsModuleSalt);
+        address module = _moduleAddress(_DRIPS_MODULE_SALT);
         require(Address.isContract(module), "Drips module not deployed");
         return DripsModule(module);
     }
@@ -150,7 +150,7 @@ contract DripsModule is DripsDependentModule, ProxyDeployerModule {
     }
 
     constructor(DripsDeployer dripsDeployer_, uint32 dripsCycleSecs_, address proxyAdmin_)
-        BaseModule(dripsDeployer_, _dripsModuleSalt)
+        BaseModule(dripsDeployer_, _DRIPS_MODULE_SALT)
     {
         dripsCycleSecs = dripsCycleSecs_;
         // slither-disable-next-line too-many-digits
@@ -179,10 +179,10 @@ contract DripsModule is DripsDependentModule, ProxyDeployerModule {
 }
 
 abstract contract CallerDependentModule is BaseModule {
-    bytes32 internal immutable _callerModuleSalt = "Caller";
+    bytes32 internal constant _CALLER_MODULE_SALT = "Caller";
 
     function _callerModule() internal view returns (CallerModule) {
-        address module = _moduleAddress(_callerModuleSalt);
+        address module = _moduleAddress(_CALLER_MODULE_SALT);
         require(Address.isContract(module), "Caller module not deployed");
         return CallerModule(module);
     }
@@ -193,7 +193,7 @@ contract CallerModule is ContractDeployerModule, CallerDependentModule {
         return abi.encode(dripsDeployer);
     }
 
-    constructor(DripsDeployer dripsDeployer_) BaseModule(dripsDeployer_, _callerModuleSalt) {
+    constructor(DripsDeployer dripsDeployer_) BaseModule(dripsDeployer_, _CALLER_MODULE_SALT) {
         // slither-disable-next-line too-many-digits
         _deployContract(type(Caller).creationCode);
     }

--- a/src/DripsDeployer.sol
+++ b/src/DripsDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {AddressDriver} from "./AddressDriver.sol";
 import {Caller} from "./Caller.sol";

--- a/src/DriverTransferUtils.sol
+++ b/src/DriverTransferUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Drips, StreamReceiver, IERC20, SafeERC20} from "./Drips.sol";
 import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";

--- a/src/Giver.sol
+++ b/src/Giver.sol
@@ -44,10 +44,8 @@ contract GiversRegistry is Managed {
     /// @notice The driver to use to `give`.
     AddressDriver public immutable addressDriver;
     /// @notice The `Drips` contract used by `addressDriver`.
-    // slither-disable-next-line naming-convention
     Drips internal immutable _drips;
     /// @notice The maximum balance of each token that Drips can hold.
-    // slither-disable-next-line naming-convention
     uint128 internal immutable _maxTotalBalance;
 
     /// @param addressDriver_ The driver to use to `give`.

--- a/src/Giver.sol
+++ b/src/Giver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {AddressDriver, Drips, IERC20} from "./AddressDriver.sol";
 import {Managed} from "./Managed.sol";

--- a/src/ImmutableSplitsDriver.sol
+++ b/src/ImmutableSplitsDriver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {AccountMetadata, Drips, SplitsReceiver} from "./Drips.sol";
 import {Managed} from "./Managed.sol";

--- a/src/Managed.sol
+++ b/src/Managed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {UUPSUpgradeable} from "openzeppelin-contracts/proxy/utils/UUPSUpgradeable.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/src/NFTDriver.sol
+++ b/src/NFTDriver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {
     AccountMetadata, Drips, StreamReceiver, IERC20, SafeERC20, SplitsReceiver

--- a/src/RepoDriver.sol
+++ b/src/RepoDriver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {
     AccountMetadata, Drips, StreamReceiver, IERC20, SafeERC20, SplitsReceiver

--- a/src/Splits.sol
+++ b/src/Splits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 

--- a/src/Streams.sol
+++ b/src/Streams.sol
@@ -161,10 +161,8 @@ abstract contract Streams {
     /// @notice On every timestamp `T`, which is a multiple of `cycleSecs`, the receivers
     /// gain access to streams received during `T - cycleSecs` to `T - 1`.
     /// Always higher than 1.
-    // slither-disable-next-line naming-convention
     uint32 internal immutable _cycleSecs;
     /// @notice The minimum amtPerSec of a stream. It's 1 token per cycle.
-    // slither-disable-next-line naming-convention
     uint160 internal immutable _minAmtPerSec;
     /// @notice The storage slot holding a single `StreamsStorage` structure.
     bytes32 private immutable _streamsStorageSlot;
@@ -1098,7 +1096,6 @@ abstract contract Streams {
             } else if (pickNew) {
                 // Create a new stream
                 StreamsState storage state = states[newRecv.accountId];
-                // slither-disable-next-line uninitialized-local
                 (uint32 start, uint32 end) =
                     _streamRangeInFuture(newRecv, _currTimestamp(), newMaxEnd);
                 int256 amtPerSec = int256(uint256(newRecv.config.amtPerSec()));

--- a/src/Streams.sol
+++ b/src/Streams.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 

--- a/src/dataStore/AddressDriverDataProxy.sol
+++ b/src/dataStore/AddressDriverDataProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {DripsDataStore} from "./DripsDataStore.sol";
 import {AddressDriver} from "../AddressDriver.sol";

--- a/src/dataStore/DripsDataProxy.sol
+++ b/src/dataStore/DripsDataProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {DripsDataStore} from "./DripsDataStore.sol";
 import {Drips, StreamReceiver, IERC20, SplitsReceiver} from "../Drips.sol";

--- a/src/dataStore/DripsDataStore.sol
+++ b/src/dataStore/DripsDataStore.sol
@@ -15,16 +15,12 @@ contract DripsDataStore {
     bytes32 public constant EMPTY_HASH = 0;
 
     /// @notice The streams receiver lists storage contract addresses.
-    // slither-disable-next-line naming-convention
     mapping(bytes32 hash => address pointer) internal _streamsPointers;
     /// @notice The splits receiver lists storage contract addresses.
-    // slither-disable-next-line naming-convention
     mapping(bytes32 hash => address pointer) internal _splitsPointers;
     /// @notice The account metadata lists storage contract addresses.
-    // slither-disable-next-line naming-convention
     mapping(bytes32 hash => address pointer) internal _accountMetadataPointers;
     /// @notice The streams history entries lists storage contract addresses.
-    // slither-disable-next-line naming-convention
     mapping(bytes32 hash => address pointer) internal _streamsHistoryPointers;
 
     /// @notice Emitted when a new streams receiver list is stored.

--- a/src/dataStore/DripsDataStore.sol
+++ b/src/dataStore/DripsDataStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {AccountMetadata, SplitsReceiver, StreamsHistory, StreamReceiver} from "../Drips.sol";
 

--- a/src/dataStore/NFTDriverDataProxy.sol
+++ b/src/dataStore/NFTDriverDataProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {DripsDataStore} from "./DripsDataStore.sol";
 import {Caller} from "../Caller.sol";

--- a/src/dataStore/RepoDriverDataProxy.sol
+++ b/src/dataStore/RepoDriverDataProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {DripsDataStore} from "./DripsDataStore.sol";
 import {Caller} from "../Caller.sol";

--- a/test/AddressDriver.t.sol
+++ b/test/AddressDriver.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Caller} from "src/Caller.sol";
 import {AddressDriver} from "src/AddressDriver.sol";

--- a/test/Caller.t.sol
+++ b/test/Caller.t.sol
@@ -44,7 +44,7 @@ contract CallerTest is Test {
         uint256 input = 1234567890;
         bytes memory data = abi.encodeCall(target.run, (input));
         uint256 value = 4321;
-        uint256 deadline = block.timestamp;
+        uint256 deadline = vm.getBlockTimestamp();
         (bytes32 r, bytes32 sv) = signCall(senderKey, target, data, value, 0, deadline);
 
         bytes memory returned =
@@ -56,7 +56,7 @@ contract CallerTest is Test {
 
     function testCallSignedRejectsExpiredDeadline() public {
         bytes memory data = abi.encodeCall(target.run, (1));
-        uint256 deadline = block.timestamp;
+        uint256 deadline = vm.getBlockTimestamp();
         skip(1);
         (bytes32 r, bytes32 sv) = signCall(senderKey, target, data, 0, 0, deadline);
 
@@ -66,7 +66,7 @@ contract CallerTest is Test {
 
     function testCallSignedRejectsInvalidNonce() public {
         bytes memory data = abi.encodeCall(target.run, (1));
-        uint256 deadline = block.timestamp;
+        uint256 deadline = vm.getBlockTimestamp();
         (bytes32 r, bytes32 sv) = signCall(senderKey, target, data, 0, 0, deadline);
         caller.callSigned(sender, address(target), data, deadline, r, sv);
         assertNonce(sender, 1);
@@ -77,7 +77,7 @@ contract CallerTest is Test {
 
     function testCallSignedRejectsInvalidSigner() public {
         bytes memory data = abi.encodeCall(target.run, (1));
-        uint256 deadline = block.timestamp;
+        uint256 deadline = vm.getBlockTimestamp();
         (bytes32 r, bytes32 sv) = signCall(senderKey + 1, target, data, 0, 0, deadline);
 
         vm.expectRevert(ERROR_SIGNATURE);
@@ -87,7 +87,7 @@ contract CallerTest is Test {
     function testCallSignedBubblesErrors() public {
         // Zero input triggers a revert in Target
         bytes memory data = abi.encodeCall(target.run, (0));
-        uint256 deadline = block.timestamp;
+        uint256 deadline = vm.getBlockTimestamp();
         (bytes32 r, bytes32 sv) = signCall(senderKey, target, data, 0, 0, deadline);
 
         vm.expectRevert(ERROR_ZERO_INPUT);

--- a/test/Caller.t.sol
+++ b/test/Caller.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";

--- a/test/Drips.t.sol
+++ b/test/Drips.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {
     AccountMetadata,

--- a/test/Drips.t.sol
+++ b/test/Drips.t.sol
@@ -69,7 +69,7 @@ contract DripsTest is Test {
     }
 
     function skipToCycleEnd() internal {
-        skip(drips.cycleSecs() - (block.timestamp % drips.cycleSecs()));
+        skip(drips.cycleSecs() - (vm.getBlockTimestamp() % drips.cycleSecs()));
     }
 
     function loadStreams(uint256 forAccount)
@@ -149,7 +149,7 @@ contract DripsTest is Test {
         storeStreams(forAccount, newReceivers);
         assertEq(realBalanceDelta, balanceDelta, "Invalid real balance delta");
         (,, uint32 updateTime, uint128 actualBalance,) = drips.streamsState(forAccount, erc20);
-        assertEq(updateTime, block.timestamp, "Invalid new last update time");
+        assertEq(updateTime, vm.getBlockTimestamp(), "Invalid new last update time");
         assertEq(balanceTo, actualBalance, "Invalid streams balance");
         assertOwnBalance(uint256(int256(ownBalanceBefore) - balanceDelta));
         assertDripsBalance(uint256(int256(dripsBalanceBefore) + balanceDelta));
@@ -473,7 +473,7 @@ contract DripsTest is Test {
         setStreams(accountId, 0, 2, receivers);
 
         // Create history
-        uint32 lastUpdate = uint32(block.timestamp);
+        uint32 lastUpdate = uint32(vm.getBlockTimestamp());
         uint32 maxEnd = lastUpdate + 2;
         StreamsHistory[] memory history = new StreamsHistory[](1);
         history[0] = StreamsHistory(0, receivers, lastUpdate, maxEnd);
@@ -541,7 +541,7 @@ contract DripsTest is Test {
         StreamReceiver[] memory receivers = streamsReceivers(receiver, 1);
         setStreams(accountId, 0, 2, receivers);
         uint256 balanceAt =
-            drips.balanceAt(accountId, erc20, receivers, uint32(block.timestamp + 1));
+            drips.balanceAt(accountId, erc20, receivers, uint32(vm.getBlockTimestamp() + 1));
         assertEq(balanceAt, 1, "Invalid balance");
     }
 

--- a/test/DriverTransferUtils.t.sol
+++ b/test/DriverTransferUtils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Caller} from "src/Caller.sol";
 import {DriverTransferUtils} from "src/DriverTransferUtils.sol";

--- a/test/Giver.t.sol
+++ b/test/Giver.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {AddressDriver, Drips, IERC20, StreamReceiver} from "src/AddressDriver.sol";

--- a/test/ImmutableSplitsDriver.t.sol
+++ b/test/ImmutableSplitsDriver.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {ImmutableSplitsDriver} from "src/ImmutableSplitsDriver.sol";
 import {AccountMetadata, Drips, SplitsReceiver} from "src/Drips.sol";

--- a/test/Managed.t.sol
+++ b/test/Managed.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Managed, ManagedProxy} from "src/Managed.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/NFTDriver.t.sol
+++ b/test/NFTDriver.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Caller} from "src/Caller.sol";
 import {NFTDriver} from "src/NFTDriver.sol";

--- a/test/RepoDriver.t.sol
+++ b/test/RepoDriver.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Caller} from "src/Caller.sol";
 import {Forge, RepoDriver} from "src/RepoDriver.sol";

--- a/test/Splits.t.sol
+++ b/test/Splits.t.sol
@@ -324,7 +324,7 @@ contract SplitsTest is Test, Splits {
         SplitsReceiver[_MAX_SPLITS_RECEIVERS] memory receiversRaw,
         uint256 receiversLengthRaw,
         uint256 totalWeightRaw
-    ) internal view returns (SplitsReceiver[] memory receivers) {
+    ) internal pure returns (SplitsReceiver[] memory receivers) {
         for (uint256 i = 0; i < receiversRaw.length; i++) {
             for (uint256 j = i + 1; j < receiversRaw.length; j++) {
                 if (receiversRaw[i].accountId > receiversRaw[j].accountId) {

--- a/test/Splits.t.sol
+++ b/test/Splits.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";

--- a/test/Streams.t.sol
+++ b/test/Streams.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";

--- a/test/Streams.t.sol
+++ b/test/Streams.t.sol
@@ -1604,7 +1604,7 @@ contract StreamsTest is Test, PseudoRandomUtils, Streams {
         return bound(streamingTimeRaw, 0, _cycleSecs * maxCycles);
     }
 
-    function sanitizeStreamsBalance(uint256 balanceRaw) internal view returns (uint128 balance) {
+    function sanitizeStreamsBalance(uint256 balanceRaw) internal pure returns (uint128 balance) {
         return uint128(bound(balanceRaw, 0, _MAX_STREAMS_BALANCE));
     }
 

--- a/test/dataStore/AddressDriverDataProxy.t.sol
+++ b/test/dataStore/AddressDriverDataProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {
     AddressDriver,

--- a/test/dataStore/DripsDataProxy.t.sol
+++ b/test/dataStore/DripsDataProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {DripsDataProxy, DripsDataStore} from "src/dataStore/DripsDataProxy.sol";
 import {

--- a/test/dataStore/DripsDataProxy.t.sol
+++ b/test/dataStore/DripsDataProxy.t.sol
@@ -105,7 +105,7 @@ contract DripsDataProxyTest is Test {
         vm.prank(driver);
         drips.setStreams(account, erc20, new StreamReceiver[](0), 2, streams, 0, 0);
 
-        uint256 balanceAt = dataProxy.balanceAt(account, erc20, uint32(block.timestamp + 1));
+        uint256 balanceAt = dataProxy.balanceAt(account, erc20, uint32(vm.getBlockTimestamp() + 1));
         assertEq(balanceAt, 1, "Invalid balance");
     }
 

--- a/test/dataStore/DripsDataStore.t.sol
+++ b/test/dataStore/DripsDataStore.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {
     AccountMetadata,

--- a/test/dataStore/NFTDriverDataProxy.t.sol
+++ b/test/dataStore/NFTDriverDataProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {DripsDataStore, NFTDriver, NFTDriverDataProxy} from "src/dataStore/NFTDriverDataProxy.sol";
 import {Call, Caller} from "src/Caller.sol";

--- a/test/dataStore/RepoDriverDataProxy.t.sol
+++ b/test/dataStore/RepoDriverDataProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {
     DripsDataStore, RepoDriver, RepoDriverDataProxy


### PR DESCRIPTION
Some changes were needed to make the code via-IR-compatible.

The behavior of the inline initialization (e.g. `uint256 internal immutable foo = 123;`) is different, it's no longer done before all the constructors are run, but only right before the constructor of the contract containing this variable, so it can't be used as a parameter of the parent contract, it's silently set to 0.

Via-IR has some problems with very large functions, it probably tries to inline them and then optimize, which it fails to do. This is why some tests needed to be prevented from inlining by making the complicated function calls external.

Via-IR assumes that `block.timestamp` never changes, so it sometimes replaces accessing variables known to be holding the timestamp with `block.timestamp` retrieval, which derailed some tests.