### PR TITLE
Make the splits weights uint256

### DIFF
--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -64,7 +64,7 @@ contract Drips is Managed, Streams, Splits {
     /// Limits the cost of splitting.
     uint256 public constant MAX_SPLITS_RECEIVERS = _MAX_SPLITS_RECEIVERS;
     /// @notice The total splits weight of an account
-    uint32 public constant TOTAL_SPLITS_WEIGHT = _TOTAL_SPLITS_WEIGHT;
+    uint256 public constant TOTAL_SPLITS_WEIGHT = _TOTAL_SPLITS_WEIGHT;
     /// @notice The offset of the controlling driver ID in the account ID.
     /// In other words the controlling driver ID is the highest 32 bits of the account ID.
     /// Every account ID is a 256-bit integer constructed by concatenating:

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -471,7 +471,7 @@ contract Drips is Managed, Streams, Splits {
     /// @return collectableAmt The amount made collectable for the account
     /// on top of what was collectable before.
     /// @return splitAmt The amount split to the account's splits receivers
-    function splitResult(uint256 accountId, SplitsReceiver[] memory currReceivers, uint128 amount)
+    function splitResult(uint256 accountId, SplitsReceiver[] calldata currReceivers, uint128 amount)
         public
         view
         onlyProxy
@@ -503,7 +503,7 @@ contract Drips is Managed, Streams, Splits {
     /// @return collectableAmt The amount made collectable for the account
     /// on top of what was collectable before.
     /// @return splitAmt The amount split to the account's splits receivers
-    function split(uint256 accountId, IERC20 erc20, SplitsReceiver[] memory currReceivers)
+    function split(uint256 accountId, IERC20 erc20, SplitsReceiver[] calldata currReceivers)
         public
         onlyProxy
         returns (uint128 collectableAmt, uint128 splitAmt)
@@ -747,7 +747,7 @@ contract Drips is Managed, Streams, Splits {
     /// This is usually unwanted, because if splitting is repeated,
     /// funds split to themselves will be again split using the current configuration.
     /// Splitting 100% to self effectively blocks splitting unless the configuration is updated.
-    function setSplits(uint256 accountId, SplitsReceiver[] memory receivers)
+    function setSplits(uint256 accountId, SplitsReceiver[] calldata receivers)
         public
         onlyProxy
         onlyDriver(accountId)
@@ -766,7 +766,7 @@ contract Drips is Managed, Streams, Splits {
     /// @param receivers The list of the splits receivers.
     /// Must be sorted by the account IDs, without duplicate account IDs and without 0 weights.
     /// @return receiversHash The hash of the list of splits receivers.
-    function hashSplits(SplitsReceiver[] memory receivers)
+    function hashSplits(SplitsReceiver[] calldata receivers)
         public
         pure
         returns (bytes32 receiversHash)

--- a/src/ImmutableSplitsDriver.sol
+++ b/src/ImmutableSplitsDriver.sol
@@ -17,7 +17,7 @@ contract ImmutableSplitsDriver is Managed {
     /// @notice The driver ID which this driver uses when calling Drips.
     uint32 public immutable driverId;
     /// @notice The required total splits weight of each splits configuration
-    uint32 public immutable totalSplitsWeight;
+    uint256 public immutable totalSplitsWeight;
     /// @notice The ERC-1967 storage slot holding a single `uint256` counter of created identities.
     bytes32 private immutable _counterSlot = _erc1967Slot("eip1967.immutableSplitsDriver.storage");
 
@@ -76,7 +76,9 @@ contract ImmutableSplitsDriver is Managed {
         uint256 weightSum = 0;
         unchecked {
             for (uint256 i = 0; i < receivers.length; i++) {
-                weightSum += receivers[i].weight;
+                uint256 weight = receivers[i].weight;
+                if (weight > totalSplitsWeight) weight = totalSplitsWeight + 1;
+                weightSum += weight;
             }
         }
         require(weightSum == totalSplitsWeight, "Invalid total receivers weight");

--- a/src/Splits.sol
+++ b/src/Splits.sol
@@ -115,11 +115,11 @@ abstract contract Splits {
     /// @return collectableAmt The amount made collectable for the account
     /// on top of what was collectable before.
     /// @return splitAmt The amount split to the account's splits receivers
-    function _splitResult(uint256 accountId, SplitsReceiver[] memory currReceivers, uint128 amount)
-        internal
-        view
-        returns (uint128 collectableAmt, uint128 splitAmt)
-    {
+    function _splitResult(
+        uint256 accountId,
+        SplitsReceiver[] calldata currReceivers,
+        uint128 amount
+    ) internal view returns (uint128 collectableAmt, uint128 splitAmt) {
         _assertCurrSplits(accountId, currReceivers);
         if (amount == 0) {
             return (0, 0);
@@ -147,7 +147,7 @@ abstract contract Splits {
     /// @return collectableAmt The amount made collectable for the account
     /// on top of what was collectable before.
     /// @return splitAmt The amount split to the account's splits receivers
-    function _split(uint256 accountId, IERC20 erc20, SplitsReceiver[] memory currReceivers)
+    function _split(uint256 accountId, IERC20 erc20, SplitsReceiver[] calldata currReceivers)
         internal
         returns (uint128 collectableAmt, uint128 splitAmt)
     {
@@ -231,7 +231,7 @@ abstract contract Splits {
     /// This is usually unwanted, because if splitting is repeated,
     /// funds split to themselves will be again split using the current configuration.
     /// Splitting 100% to self effectively blocks splitting unless the configuration is updated.
-    function _setSplits(uint256 accountId, SplitsReceiver[] memory receivers) internal {
+    function _setSplits(uint256 accountId, SplitsReceiver[] calldata receivers) internal {
         SplitsState storage state = _splitsStorage().splitsStates[accountId];
         bytes32 newSplitsHash = _hashSplits(receivers);
         if (newSplitsHash == state.splitsHash) return;
@@ -244,13 +244,13 @@ abstract contract Splits {
     /// @notice Validates a list of splits receivers and emits events for them
     /// @param receivers The list of splits receivers
     /// Must be sorted by the account IDs, without duplicate account IDs and without 0 weights.
-    function _assertSplitsValid(SplitsReceiver[] memory receivers) private pure {
+    function _assertSplitsValid(SplitsReceiver[] calldata receivers) private pure {
         unchecked {
             require(receivers.length <= _MAX_SPLITS_RECEIVERS, "Too many splits receivers");
             uint256 totalWeight = 0;
             uint256 prevAccountId = 0;
             for (uint256 i = 0; i < receivers.length; i++) {
-                SplitsReceiver memory receiver = receivers[i];
+                SplitsReceiver calldata receiver = receivers[i];
                 uint256 weight = receiver.weight;
                 require(weight != 0, "Splits receiver weight is zero");
                 if (weight > _TOTAL_SPLITS_WEIGHT) weight = _TOTAL_SPLITS_WEIGHT + 1;
@@ -267,7 +267,7 @@ abstract contract Splits {
     /// @param accountId The account ID.
     /// @param currReceivers The list of the account's current splits receivers.
     /// If the splits have never been set, pass an empty array.
-    function _assertCurrSplits(uint256 accountId, SplitsReceiver[] memory currReceivers)
+    function _assertCurrSplits(uint256 accountId, SplitsReceiver[] calldata currReceivers)
         internal
         view
     {
@@ -287,7 +287,7 @@ abstract contract Splits {
     /// @param receivers The list of the splits receivers.
     /// If the splits have never been set, pass an empty array.
     /// @return receiversHash The hash of the list of splits receivers.
-    function _hashSplits(SplitsReceiver[] memory receivers)
+    function _hashSplits(SplitsReceiver[] calldata receivers)
         internal
         pure
         returns (bytes32 receiversHash)

--- a/test/Drips.t.sol
+++ b/test/Drips.t.sol
@@ -192,7 +192,7 @@ contract DripsTest is Test {
         list = new SplitsReceiver[](0);
     }
 
-    function splitsReceivers(uint256 splitsReceiver, uint32 weight)
+    function splitsReceivers(uint256 splitsReceiver, uint256 weight)
         internal
         pure
         returns (SplitsReceiver[] memory list)
@@ -203,9 +203,9 @@ contract DripsTest is Test {
 
     function splitsReceivers(
         uint256 splitsReceiver1,
-        uint32 weight1,
+        uint256 weight1,
         uint256 splitsReceiver2,
-        uint32 weight2
+        uint256 weight2
     ) internal pure returns (SplitsReceiver[] memory list) {
         list = new SplitsReceiver[](2);
         list[0] = SplitsReceiver(splitsReceiver1, weight1);
@@ -418,7 +418,7 @@ contract DripsTest is Test {
     }
 
     function testUncollectedFundsAreSplitUsingCurrentConfig() public {
-        uint32 totalWeight = drips.TOTAL_SPLITS_WEIGHT();
+        uint256 totalWeight = drips.TOTAL_SPLITS_WEIGHT();
         setSplits(accountId1, splitsReceivers(receiver1, totalWeight));
         setStreams(accountId2, 0, 5, streamsReceivers(accountId1, 5));
         skipToCycleEnd();
@@ -508,7 +508,7 @@ contract DripsTest is Test {
     }
 
     function testSplitSplitsFundsReceivedFromAllSources() public {
-        uint32 totalWeight = drips.TOTAL_SPLITS_WEIGHT();
+        uint256 totalWeight = drips.TOTAL_SPLITS_WEIGHT();
         // Gives
         give(accountId2, accountId1, 1);
 

--- a/test/dataStore/DripsDataProxy.t.sol
+++ b/test/dataStore/DripsDataProxy.t.sol
@@ -63,7 +63,7 @@ contract DripsDataProxyTest is Test {
     }
 
     function testSplit() public {
-        uint32 splitWeight = drips.TOTAL_SPLITS_WEIGHT() / 4;
+        uint256 splitWeight = drips.TOTAL_SPLITS_WEIGHT() / 4;
         uint128 totalAmt = 8;
         uint128 splitAmt = 2;
         uint128 collectableAmt = 6;


### PR DESCRIPTION
This makes the API simpler and more sane, it requires less effort and gas to parse and validate the calldata.