### PR TITLE
Make max end hints a custom type

### DIFF
--- a/src/AddressDriver.sol
+++ b/src/AddressDriver.sol
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.24;
 
-import {AccountMetadata, Drips, StreamReceiver, IERC20, SplitsReceiver} from "./Drips.sol";
+import {
+    AccountMetadata,
+    Drips,
+    MaxEndHints,
+    StreamReceiver,
+    IERC20,
+    SplitsReceiver
+} from "./Drips.sol";
 import {Managed} from "./Managed.sol";
 import {DriverTransferUtils} from "./DriverTransferUtils.sol";
 
@@ -95,29 +102,31 @@ contract AddressDriver is DriverTransferUtils, Managed {
     /// @param newReceivers The list of the streams receivers of the sender to be set.
     /// Must be sorted by the account IDs and then by the stream configurations,
     /// without identical elements and without 0 amtPerSecs.
-    /// @param maxEndHint1 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The first hint for finding the maximum end time when all streams stop due to funds
-    /// running out after the balance is updated and the new receivers list is applied.
+    /// @param maxEndHints An optional parameter allowing gas optimization.
+    /// To not use this feature pass an integer `0`, it represents a list of 8 zero value hints.
+    /// This argument is a list of hints for finding the timestamp when all streams stop
+    /// due to funds running out after the streams configuration is updated.
     /// Hints have no effect on the results of calling this function, except potentially saving gas.
     /// Hints are Unix timestamps used as the starting points for binary search for the time
     /// when funds run out in the range of timestamps from the current block's to `2^32`.
-    /// Hints lower than the current timestamp are ignored.
-    /// You can provide zero, one or two hints. The order of hints doesn't matter.
+    /// Hints lower than the current timestamp including the zero value hints are ignored.
+    /// If you provide fewer than 8 non-zero value hints make them the rightmost values to save gas.
+    /// It's the most beneficial to make the most risky and precise hints
+    /// the rightmost ones, but there's no strict ordering requirement.
     /// Hints are the most effective when one of them is lower than or equal to
     /// the last timestamp when funds are still streamed, and the other one is strictly larger
-    /// than that timestamp,the smaller the difference between such hints, the higher gas savings.
+    /// than that timestamp, the smaller the difference between such hints, the more gas is saved.
     /// The savings are the highest possible when one of the hints is equal to
     /// the last timestamp when funds are still streamed, and the other one is larger by 1.
     /// It's worth noting that the exact timestamp of the block in which this function is executed
-    /// may affect correctness of the hints, especially if they're precise.
+    /// may affect correctness of the hints, especially if they're precise,
+    /// which is why you may want to pass multiple hints with varying precision.
     /// Hints don't provide any benefits when balance is not enough to cover
     /// a single second of streaming or is enough to cover all streams until timestamp `2^32`.
     /// Even inaccurate hints can be useful, and providing a single hint
-    /// or two hints that don't enclose the time when funds run out can still save some gas.
+    /// or hints that don't enclose the time when funds run out can still save some gas.
     /// Providing poor hints that don't reduce the number of binary search steps
     /// may cause slightly higher gas usage than not providing any hints.
-    /// @param maxEndHint2 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The second hint for finding the maximum end time, see `maxEndHint1` docs for more details.
     /// @param transferTo The address to send funds to in case of decreasing balance
     /// @return realBalanceDelta The actually applied streams balance change.
     /// It's equal to the passed `balanceDelta`, unless it's negative
@@ -127,9 +136,7 @@ contract AddressDriver is DriverTransferUtils, Managed {
         StreamReceiver[] calldata currReceivers,
         int128 balanceDelta,
         StreamReceiver[] calldata newReceivers,
-        // slither-disable-next-line similar-names
-        uint32 maxEndHint1,
-        uint32 maxEndHint2,
+        MaxEndHints maxEndHints,
         address transferTo
     ) public onlyProxy returns (int128 realBalanceDelta) {
         return _setStreamsAndTransfer(
@@ -139,8 +146,7 @@ contract AddressDriver is DriverTransferUtils, Managed {
             currReceivers,
             balanceDelta,
             newReceivers,
-            maxEndHint1,
-            maxEndHint2,
+            maxEndHints,
             transferTo
         );
     }

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -2,7 +2,13 @@
 pragma solidity ^0.8.24;
 
 import {
-    Streams, StreamConfig, StreamsHistory, StreamConfigImpl, StreamReceiver
+    MaxEndHints,
+    MaxEndHintsImpl,
+    StreamConfig,
+    StreamConfigImpl,
+    Streams,
+    StreamsHistory,
+    StreamReceiver
 } from "./Streams.sol";
 import {Managed} from "./Managed.sol";
 import {Splits, SplitsReceiver} from "./Splits.sol";
@@ -650,29 +656,31 @@ contract Drips is Managed, Streams, Splits {
     /// @param newReceivers The list of the streams receivers of the account to be set.
     /// Must be sorted by the account IDs and then by the stream configurations,
     /// without identical elements and without 0 amtPerSecs.
-    /// @param maxEndHint1 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The first hint for finding the maximum end time when all streams stop due to funds
-    /// running out after the balance is updated and the new receivers list is applied.
+    /// @param maxEndHints An optional parameter allowing gas optimization.
+    /// To not use this feature pass an integer `0`, it represents a list of 8 zero value hints.
+    /// This argument is a list of hints for finding the timestamp when all streams stop
+    /// due to funds running out after the streams configuration is updated.
     /// Hints have no effect on the results of calling this function, except potentially saving gas.
     /// Hints are Unix timestamps used as the starting points for binary search for the time
     /// when funds run out in the range of timestamps from the current block's to `2^32`.
-    /// Hints lower than the current timestamp are ignored.
-    /// You can provide zero, one or two hints. The order of hints doesn't matter.
+    /// Hints lower than the current timestamp including the zero value hints are ignored.
+    /// If you provide fewer than 8 non-zero value hints make them the rightmost values to save gas.
+    /// It's the most beneficial to make the most risky and precise hints
+    /// the rightmost ones, but there's no strict ordering requirement.
     /// Hints are the most effective when one of them is lower than or equal to
     /// the last timestamp when funds are still streamed, and the other one is strictly larger
-    /// than that timestamp,the smaller the difference between such hints, the higher gas savings.
+    /// than that timestamp, the smaller the difference between such hints, the more gas is saved.
     /// The savings are the highest possible when one of the hints is equal to
     /// the last timestamp when funds are still streamed, and the other one is larger by 1.
     /// It's worth noting that the exact timestamp of the block in which this function is executed
-    /// may affect correctness of the hints, especially if they're precise.
+    /// may affect correctness of the hints, especially if they're precise,
+    /// which is why you may want to pass multiple hints with varying precision.
     /// Hints don't provide any benefits when balance is not enough to cover
     /// a single second of streaming or is enough to cover all streams until timestamp `2^32`.
     /// Even inaccurate hints can be useful, and providing a single hint
-    /// or two hints that don't enclose the time when funds run out can still save some gas.
+    /// or hints that don't enclose the time when funds run out can still save some gas.
     /// Providing poor hints that don't reduce the number of binary search steps
     /// may cause slightly higher gas usage than not providing any hints.
-    /// @param maxEndHint2 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The second hint for finding the maximum end time, see `maxEndHint1` docs for more details.
     /// @return realBalanceDelta The actually applied streams balance change.
     /// It's equal to the passed `balanceDelta`, unless it's negative
     /// and it gets capped at the current balance amount.
@@ -683,13 +691,11 @@ contract Drips is Managed, Streams, Splits {
         StreamReceiver[] memory currReceivers,
         int128 balanceDelta,
         StreamReceiver[] memory newReceivers,
-        // slither-disable-next-line similar-names
-        uint32 maxEndHint1,
-        uint32 maxEndHint2
+        MaxEndHints maxEndHints
     ) public onlyProxy onlyDriver(accountId) returns (int128 realBalanceDelta) {
         if (balanceDelta > 0) _increaseStreamsBalance(erc20, uint128(balanceDelta));
         realBalanceDelta = Streams._setStreams(
-            accountId, erc20, currReceivers, balanceDelta, newReceivers, maxEndHint1, maxEndHint2
+            accountId, erc20, currReceivers, balanceDelta, newReceivers, maxEndHints
         );
         if (realBalanceDelta < 0) _decreaseStreamsBalance(erc20, uint128(-realBalanceDelta));
     }

--- a/src/NFTDriver.sol
+++ b/src/NFTDriver.sol
@@ -2,7 +2,13 @@
 pragma solidity ^0.8.24;
 
 import {
-    AccountMetadata, Drips, StreamReceiver, IERC20, SafeERC20, SplitsReceiver
+    AccountMetadata,
+    Drips,
+    MaxEndHints,
+    StreamReceiver,
+    IERC20,
+    SafeERC20,
+    SplitsReceiver
 } from "./Drips.sol";
 import {DriverTransferUtils, ERC2771Context} from "./DriverTransferUtils.sol";
 import {Managed} from "./Managed.sol";
@@ -262,29 +268,31 @@ contract NFTDriver is ERC721Burnable, DriverTransferUtils, Managed {
     /// @param newReceivers The list of the streams receivers of the sender to be set.
     /// Must be sorted by the account IDs and then by the stream configurations,
     /// without identical elements and without 0 amtPerSecs.
-    /// @param maxEndHint1 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The first hint for finding the maximum end time when all streams stop due to funds
-    /// running out after the balance is updated and the new receivers list is applied.
+    /// @param maxEndHints An optional parameter allowing gas optimization.
+    /// To not use this feature pass an integer `0`, it represents a list of 8 zero value hints.
+    /// This argument is a list of hints for finding the timestamp when all streams stop
+    /// due to funds running out after the streams configuration is updated.
     /// Hints have no effect on the results of calling this function, except potentially saving gas.
     /// Hints are Unix timestamps used as the starting points for binary search for the time
     /// when funds run out in the range of timestamps from the current block's to `2^32`.
-    /// Hints lower than the current timestamp are ignored.
-    /// You can provide zero, one or two hints. The order of hints doesn't matter.
+    /// Hints lower than the current timestamp including the zero value hints are ignored.
+    /// If you provide fewer than 8 non-zero value hints make them the rightmost values to save gas.
+    /// It's the most beneficial to make the most risky and precise hints
+    /// the rightmost ones, but there's no strict ordering requirement.
     /// Hints are the most effective when one of them is lower than or equal to
     /// the last timestamp when funds are still streamed, and the other one is strictly larger
-    /// than that timestamp,the smaller the difference between such hints, the higher gas savings.
+    /// than that timestamp, the smaller the difference between such hints, the more gas is saved.
     /// The savings are the highest possible when one of the hints is equal to
     /// the last timestamp when funds are still streamed, and the other one is larger by 1.
     /// It's worth noting that the exact timestamp of the block in which this function is executed
-    /// may affect correctness of the hints, especially if they're precise.
+    /// may affect correctness of the hints, especially if they're precise,
+    /// which is why you may want to pass multiple hints with varying precision.
     /// Hints don't provide any benefits when balance is not enough to cover
     /// a single second of streaming or is enough to cover all streams until timestamp `2^32`.
     /// Even inaccurate hints can be useful, and providing a single hint
-    /// or two hints that don't enclose the time when funds run out can still save some gas.
+    /// or hints that don't enclose the time when funds run out can still save some gas.
     /// Providing poor hints that don't reduce the number of binary search steps
     /// may cause slightly higher gas usage than not providing any hints.
-    /// @param maxEndHint2 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The second hint for finding the maximum end time, see `maxEndHint1` docs for more details.
     /// @param transferTo The address to send funds to in case of decreasing balance
     /// @return realBalanceDelta The actually applied streams balance change.
     /// It's equal to the passed `balanceDelta`, unless it's negative
@@ -295,9 +303,7 @@ contract NFTDriver is ERC721Burnable, DriverTransferUtils, Managed {
         StreamReceiver[] calldata currReceivers,
         int128 balanceDelta,
         StreamReceiver[] calldata newReceivers,
-        // slither-disable-next-line similar-names
-        uint32 maxEndHint1,
-        uint32 maxEndHint2,
+        MaxEndHints maxEndHints,
         address transferTo
     ) public onlyProxy onlyApprovedOrOwner(tokenId) returns (int128 realBalanceDelta) {
         return _setStreamsAndTransfer(
@@ -307,8 +313,7 @@ contract NFTDriver is ERC721Burnable, DriverTransferUtils, Managed {
             currReceivers,
             balanceDelta,
             newReceivers,
-            maxEndHint1,
-            maxEndHint2,
+            maxEndHints,
             transferTo
         );
     }

--- a/src/RepoDriver.sol
+++ b/src/RepoDriver.sol
@@ -2,7 +2,13 @@
 pragma solidity ^0.8.24;
 
 import {
-    AccountMetadata, Drips, StreamReceiver, IERC20, SafeERC20, SplitsReceiver
+    AccountMetadata,
+    Drips,
+    MaxEndHints,
+    StreamReceiver,
+    IERC20,
+    SafeERC20,
+    SplitsReceiver
 } from "./Drips.sol";
 import {DriverTransferUtils} from "./DriverTransferUtils.sol";
 import {Managed} from "./Managed.sol";
@@ -457,29 +463,31 @@ contract RepoDriver is ERC677ReceiverInterface, DriverTransferUtils, Managed {
     /// @param newReceivers The list of the streams receivers of the sender to be set.
     /// Must be sorted by the account IDs and then by the stream configurations,
     /// without identical elements and without 0 amtPerSecs.
-    /// @param maxEndHint1 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The first hint for finding the maximum end time when all streams stop due to funds
-    /// running out after the balance is updated and the new receivers list is applied.
+    /// @param maxEndHints An optional parameter allowing gas optimization.
+    /// To not use this feature pass an integer `0`, it represents a list of 8 zero value hints.
+    /// This argument is a list of hints for finding the timestamp when all streams stop
+    /// due to funds running out after the streams configuration is updated.
     /// Hints have no effect on the results of calling this function, except potentially saving gas.
     /// Hints are Unix timestamps used as the starting points for binary search for the time
     /// when funds run out in the range of timestamps from the current block's to `2^32`.
-    /// Hints lower than the current timestamp are ignored.
-    /// You can provide zero, one or two hints. The order of hints doesn't matter.
+    /// Hints lower than the current timestamp including the zero value hints are ignored.
+    /// If you provide fewer than 8 non-zero value hints make them the rightmost values to save gas.
+    /// It's the most beneficial to make the most risky and precise hints
+    /// the rightmost ones, but there's no strict ordering requirement.
     /// Hints are the most effective when one of them is lower than or equal to
     /// the last timestamp when funds are still streamed, and the other one is strictly larger
-    /// than that timestamp,the smaller the difference between such hints, the higher gas savings.
+    /// than that timestamp, the smaller the difference between such hints, the more gas is saved.
     /// The savings are the highest possible when one of the hints is equal to
     /// the last timestamp when funds are still streamed, and the other one is larger by 1.
     /// It's worth noting that the exact timestamp of the block in which this function is executed
-    /// may affect correctness of the hints, especially if they're precise.
+    /// may affect correctness of the hints, especially if they're precise,
+    /// which is why you may want to pass multiple hints with varying precision.
     /// Hints don't provide any benefits when balance is not enough to cover
     /// a single second of streaming or is enough to cover all streams until timestamp `2^32`.
     /// Even inaccurate hints can be useful, and providing a single hint
-    /// or two hints that don't enclose the time when funds run out can still save some gas.
+    /// or hints that don't enclose the time when funds run out can still save some gas.
     /// Providing poor hints that don't reduce the number of binary search steps
     /// may cause slightly higher gas usage than not providing any hints.
-    /// @param maxEndHint2 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The second hint for finding the maximum end time, see `maxEndHint1` docs for more details.
     /// @param transferTo The address to send funds to in case of decreasing balance
     /// @return realBalanceDelta The actually applied streams balance change.
     /// It's equal to the passed `balanceDelta`, unless it's negative
@@ -490,9 +498,7 @@ contract RepoDriver is ERC677ReceiverInterface, DriverTransferUtils, Managed {
         StreamReceiver[] calldata currReceivers,
         int128 balanceDelta,
         StreamReceiver[] calldata newReceivers,
-        // slither-disable-next-line similar-names
-        uint32 maxEndHint1,
-        uint32 maxEndHint2,
+        MaxEndHints maxEndHints,
         address transferTo
     ) public onlyProxy onlyOwner(accountId) returns (int128 realBalanceDelta) {
         return _setStreamsAndTransfer(
@@ -502,8 +508,7 @@ contract RepoDriver is ERC677ReceiverInterface, DriverTransferUtils, Managed {
             currReceivers,
             balanceDelta,
             newReceivers,
-            maxEndHint1,
-            maxEndHint2,
+            maxEndHints,
             transferTo
         );
     }

--- a/src/dataStore/AddressDriverDataProxy.sol
+++ b/src/dataStore/AddressDriverDataProxy.sol
@@ -4,7 +4,14 @@ pragma solidity ^0.8.24;
 import {DripsDataStore} from "./DripsDataStore.sol";
 import {AddressDriver} from "../AddressDriver.sol";
 import {Caller} from "../Caller.sol";
-import {AccountMetadata, Drips, StreamReceiver, IERC20, SplitsReceiver} from "../Drips.sol";
+import {
+    AccountMetadata,
+    Drips,
+    MaxEndHints,
+    StreamReceiver,
+    IERC20,
+    SplitsReceiver
+} from "../Drips.sol";
 import {Managed} from "../Managed.sol";
 import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
 
@@ -64,29 +71,31 @@ contract AddressDriverDataProxy is ERC2771Context, Managed {
     /// the actual list must be stored in DripsDataStore.
     /// Must be sorted by the account IDs and then by the stream configurations,
     /// without identical elements and without 0 amtPerSecs.
-    /// @param maxEndHint1 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The first hint for finding the maximum end time when all streams stop due to funds
-    /// running out after the balance is updated and the new receivers list is applied.
+    /// @param maxEndHints An optional parameter allowing gas optimization.
+    /// To not use this feature pass an integer `0`, it represents a list of 8 zero value hints.
+    /// This argument is a list of hints for finding the timestamp when all streams stop
+    /// due to funds running out after the streams configuration is updated.
     /// Hints have no effect on the results of calling this function, except potentially saving gas.
     /// Hints are Unix timestamps used as the starting points for binary search for the time
     /// when funds run out in the range of timestamps from the current block's to `2^32`.
-    /// Hints lower than the current timestamp are ignored.
-    /// You can provide zero, one or two hints. The order of hints doesn't matter.
+    /// Hints lower than the current timestamp including the zero value hints are ignored.
+    /// If you provide fewer than 8 non-zero value hints make them the rightmost values to save gas.
+    /// It's the most beneficial to make the most risky and precise hints
+    /// the rightmost ones, but there's no strict ordering requirement.
     /// Hints are the most effective when one of them is lower than or equal to
     /// the last timestamp when funds are still streamed, and the other one is strictly larger
-    /// than that timestamp,the smaller the difference between such hints, the higher gas savings.
+    /// than that timestamp, the smaller the difference between such hints, the more gas is saved.
     /// The savings are the highest possible when one of the hints is equal to
     /// the last timestamp when funds are still streamed, and the other one is larger by 1.
     /// It's worth noting that the exact timestamp of the block in which this function is executed
-    /// may affect correctness of the hints, especially if they're precise.
+    /// may affect correctness of the hints, especially if they're precise,
+    /// which is why you may want to pass multiple hints with varying precision.
     /// Hints don't provide any benefits when balance is not enough to cover
     /// a single second of streaming or is enough to cover all streams until timestamp `2^32`.
     /// Even inaccurate hints can be useful, and providing a single hint
-    /// or two hints that don't enclose the time when funds run out can still save some gas.
+    /// or hints that don't enclose the time when funds run out can still save some gas.
     /// Providing poor hints that don't reduce the number of binary search steps
     /// may cause slightly higher gas usage than not providing any hints.
-    /// @param maxEndHint2 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The second hint for finding the maximum end time, see `maxEndHint1` docs for more details.
     /// @param transferTo The address to send funds to in case of decreasing balance
     /// @return realBalanceDelta The actually applied streams balance change.
     /// It's equal to the passed `balanceDelta`, unless it's negative
@@ -95,9 +104,7 @@ contract AddressDriverDataProxy is ERC2771Context, Managed {
         IERC20 erc20,
         int128 balanceDelta,
         bytes32 newStreamsHash,
-        // slither-disable-next-line similar-names
-        uint32 maxEndHint1,
-        uint32 maxEndHint2,
+        MaxEndHints maxEndHints,
         address transferTo
     ) public onlyProxy returns (int128 realBalanceDelta) {
         uint256 accountId = addressDriver.calcAccountId(_msgSender());
@@ -110,8 +117,7 @@ contract AddressDriverDataProxy is ERC2771Context, Managed {
                 dripsDataStore.loadStreams(currStreamsHash),
                 balanceDelta,
                 dripsDataStore.loadStreams(newStreamsHash),
-                maxEndHint1,
-                maxEndHint2,
+                maxEndHints,
                 transferTo
             )
         );

--- a/src/dataStore/NFTDriverDataProxy.sol
+++ b/src/dataStore/NFTDriverDataProxy.sol
@@ -3,7 +3,14 @@ pragma solidity ^0.8.24;
 
 import {DripsDataStore} from "./DripsDataStore.sol";
 import {Caller} from "../Caller.sol";
-import {AccountMetadata, Drips, StreamReceiver, IERC20, SplitsReceiver} from "../Drips.sol";
+import {
+    AccountMetadata,
+    Drips,
+    MaxEndHints,
+    StreamReceiver,
+    IERC20,
+    SplitsReceiver
+} from "../Drips.sol";
 import {NFTDriver} from "../NFTDriver.sol";
 import {Managed} from "../Managed.sol";
 import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
@@ -150,29 +157,31 @@ contract NFTDriverDataProxy is ERC2771Context, Managed {
     /// the actual list must be stored in DripsDataStore.
     /// Must be sorted by the account IDs and then by the stream configurations,
     /// without identical elements and without 0 amtPerSecs.
-    /// @param maxEndHint1 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The first hint for finding the maximum end time when all streams stop due to funds
-    /// running out after the balance is updated and the new receivers list is applied.
+    /// @param maxEndHints An optional parameter allowing gas optimization.
+    /// To not use this feature pass an integer `0`, it represents a list of 8 zero value hints.
+    /// This argument is a list of hints for finding the timestamp when all streams stop
+    /// due to funds running out after the streams configuration is updated.
     /// Hints have no effect on the results of calling this function, except potentially saving gas.
     /// Hints are Unix timestamps used as the starting points for binary search for the time
     /// when funds run out in the range of timestamps from the current block's to `2^32`.
-    /// Hints lower than the current timestamp are ignored.
-    /// You can provide zero, one or two hints. The order of hints doesn't matter.
+    /// Hints lower than the current timestamp including the zero value hints are ignored.
+    /// If you provide fewer than 8 non-zero value hints make them the rightmost values to save gas.
+    /// It's the most beneficial to make the most risky and precise hints
+    /// the rightmost ones, but there's no strict ordering requirement.
     /// Hints are the most effective when one of them is lower than or equal to
     /// the last timestamp when funds are still streamed, and the other one is strictly larger
-    /// than that timestamp,the smaller the difference between such hints, the higher gas savings.
+    /// than that timestamp, the smaller the difference between such hints, the more gas is saved.
     /// The savings are the highest possible when one of the hints is equal to
     /// the last timestamp when funds are still streamed, and the other one is larger by 1.
     /// It's worth noting that the exact timestamp of the block in which this function is executed
-    /// may affect correctness of the hints, especially if they're precise.
+    /// may affect correctness of the hints, especially if they're precise,
+    /// which is why you may want to pass multiple hints with varying precision.
     /// Hints don't provide any benefits when balance is not enough to cover
     /// a single second of streaming or is enough to cover all streams until timestamp `2^32`.
     /// Even inaccurate hints can be useful, and providing a single hint
-    /// or two hints that don't enclose the time when funds run out can still save some gas.
+    /// or hints that don't enclose the time when funds run out can still save some gas.
     /// Providing poor hints that don't reduce the number of binary search steps
     /// may cause slightly higher gas usage than not providing any hints.
-    /// @param maxEndHint2 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The second hint for finding the maximum end time, see `maxEndHint1` docs for more details.
     /// @param transferTo The address to send funds to in case of decreasing balance
     /// @return realBalanceDelta The actually applied streams balance change.
     /// It's equal to the passed `balanceDelta`, unless it's negative
@@ -182,9 +191,7 @@ contract NFTDriverDataProxy is ERC2771Context, Managed {
         IERC20 erc20,
         int128 balanceDelta,
         bytes32 newStreamsHash,
-        // slither-disable-next-line similar-names
-        uint32 maxEndHint1,
-        uint32 maxEndHint2,
+        MaxEndHints maxEndHints,
         address transferTo
     ) public onlyProxy returns (int128 realBalanceDelta) {
         // slither-disable-next-line unused-return
@@ -197,8 +204,7 @@ contract NFTDriverDataProxy is ERC2771Context, Managed {
                 dripsDataStore.loadStreams(currStreamsHash),
                 balanceDelta,
                 dripsDataStore.loadStreams(newStreamsHash),
-                maxEndHint1,
-                maxEndHint2,
+                maxEndHints,
                 transferTo
             )
         );

--- a/src/dataStore/RepoDriverDataProxy.sol
+++ b/src/dataStore/RepoDriverDataProxy.sol
@@ -3,7 +3,14 @@ pragma solidity ^0.8.24;
 
 import {DripsDataStore} from "./DripsDataStore.sol";
 import {Caller} from "../Caller.sol";
-import {AccountMetadata, Drips, StreamReceiver, IERC20, SplitsReceiver} from "../Drips.sol";
+import {
+    AccountMetadata,
+    Drips,
+    MaxEndHints,
+    StreamReceiver,
+    IERC20,
+    SplitsReceiver
+} from "../Drips.sol";
 import {Managed} from "../Managed.sol";
 import {RepoDriver} from "../RepoDriver.sol";
 import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
@@ -67,29 +74,31 @@ contract RepoDriverDataProxy is ERC2771Context, Managed {
     /// the actual list must be stored in DripsDataStore.
     /// Must be sorted by the account IDs and then by the stream configurations,
     /// without identical elements and without 0 amtPerSecs.
-    /// @param maxEndHint1 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The first hint for finding the maximum end time when all streams stop due to funds
-    /// running out after the balance is updated and the new receivers list is applied.
+    /// @param maxEndHints An optional parameter allowing gas optimization.
+    /// To not use this feature pass an integer `0`, it represents a list of 8 zero value hints.
+    /// This argument is a list of hints for finding the timestamp when all streams stop
+    /// due to funds running out after the streams configuration is updated.
     /// Hints have no effect on the results of calling this function, except potentially saving gas.
     /// Hints are Unix timestamps used as the starting points for binary search for the time
     /// when funds run out in the range of timestamps from the current block's to `2^32`.
-    /// Hints lower than the current timestamp are ignored.
-    /// You can provide zero, one or two hints. The order of hints doesn't matter.
+    /// Hints lower than the current timestamp including the zero value hints are ignored.
+    /// If you provide fewer than 8 non-zero value hints make them the rightmost values to save gas.
+    /// It's the most beneficial to make the most risky and precise hints
+    /// the rightmost ones, but there's no strict ordering requirement.
     /// Hints are the most effective when one of them is lower than or equal to
     /// the last timestamp when funds are still streamed, and the other one is strictly larger
-    /// than that timestamp,the smaller the difference between such hints, the higher gas savings.
+    /// than that timestamp, the smaller the difference between such hints, the more gas is saved.
     /// The savings are the highest possible when one of the hints is equal to
     /// the last timestamp when funds are still streamed, and the other one is larger by 1.
     /// It's worth noting that the exact timestamp of the block in which this function is executed
-    /// may affect correctness of the hints, especially if they're precise.
+    /// may affect correctness of the hints, especially if they're precise,
+    /// which is why you may want to pass multiple hints with varying precision.
     /// Hints don't provide any benefits when balance is not enough to cover
     /// a single second of streaming or is enough to cover all streams until timestamp `2^32`.
     /// Even inaccurate hints can be useful, and providing a single hint
-    /// or two hints that don't enclose the time when funds run out can still save some gas.
+    /// or hints that don't enclose the time when funds run out can still save some gas.
     /// Providing poor hints that don't reduce the number of binary search steps
     /// may cause slightly higher gas usage than not providing any hints.
-    /// @param maxEndHint2 An optional parameter allowing gas optimization, pass `0` to ignore it.
-    /// The second hint for finding the maximum end time, see `maxEndHint1` docs for more details.
     /// @param transferTo The address to send funds to in case of decreasing balance
     /// @return realBalanceDelta The actually applied streams balance change.
     /// It's equal to the passed `balanceDelta`, unless it's negative
@@ -99,9 +108,7 @@ contract RepoDriverDataProxy is ERC2771Context, Managed {
         IERC20 erc20,
         int128 balanceDelta,
         bytes32 newStreamsHash,
-        // slither-disable-next-line similar-names
-        uint32 maxEndHint1,
-        uint32 maxEndHint2,
+        MaxEndHints maxEndHints,
         address transferTo
     ) public onlyProxy returns (int128 realBalanceDelta) {
         // slither-disable-next-line unused-return
@@ -114,8 +121,7 @@ contract RepoDriverDataProxy is ERC2771Context, Managed {
                 dripsDataStore.loadStreams(currStreamsHash),
                 balanceDelta,
                 dripsDataStore.loadStreams(newStreamsHash),
-                maxEndHint1,
-                maxEndHint2,
+                maxEndHints,
                 transferTo
             )
         );

--- a/test/AddressDriver.t.sol
+++ b/test/AddressDriver.t.sol
@@ -6,6 +6,8 @@ import {AddressDriver} from "src/AddressDriver.sol";
 import {
     AccountMetadata,
     Drips,
+    MaxEndHints,
+    MaxEndHintsImpl,
     StreamConfigImpl,
     StreamsHistory,
     StreamReceiver,
@@ -27,6 +29,8 @@ contract AddressDriverTest is Test {
     uint256 internal thisId;
     address internal user = address(1);
     uint256 internal accountId;
+
+    MaxEndHints internal immutable noHints = MaxEndHintsImpl.create();
 
     function setUp() public {
         Drips dripsLogic = new Drips(10);
@@ -101,7 +105,7 @@ contract AddressDriverTest is Test {
         uint256 balance = erc20.balanceOf(address(this));
 
         int128 realBalanceDelta = driver.setStreams(
-            erc20, new StreamReceiver[](0), int128(amt), receivers, 0, 0, address(this)
+            erc20, new StreamReceiver[](0), int128(amt), receivers, noHints, address(this)
         );
 
         assertEq(erc20.balanceOf(address(this)), balance - amt, "Invalid balance after top-up");
@@ -115,7 +119,7 @@ contract AddressDriverTest is Test {
         balance = erc20.balanceOf(address(user));
 
         realBalanceDelta =
-            driver.setStreams(erc20, receivers, -int128(amt), receivers, 0, 0, address(user));
+            driver.setStreams(erc20, receivers, -int128(amt), receivers, noHints, address(user));
 
         assertEq(erc20.balanceOf(address(user)), balance + amt, "Invalid balance after withdrawal");
         assertEq(erc20.balanceOf(address(drips)), 0, "Invalid Drips balance after withdrawal");
@@ -127,11 +131,11 @@ contract AddressDriverTest is Test {
     function testSetStreamsDecreasingBalanceTransfersFundsToTheProvidedAddress() public {
         uint128 amt = 5;
         StreamReceiver[] memory receivers = new StreamReceiver[](0);
-        driver.setStreams(erc20, receivers, int128(amt), receivers, 0, 0, address(this));
+        driver.setStreams(erc20, receivers, int128(amt), receivers, noHints, address(this));
         address transferTo = address(1234);
 
         int128 realBalanceDelta =
-            driver.setStreams(erc20, receivers, -int128(amt), receivers, 0, 0, transferTo);
+            driver.setStreams(erc20, receivers, -int128(amt), receivers, noHints, transferTo);
 
         assertEq(erc20.balanceOf(transferTo), amt, "Invalid balance");
         assertEq(erc20.balanceOf(address(drips)), 0, "Invalid Drips balance");
@@ -188,7 +192,7 @@ contract AddressDriverTest is Test {
 
     function testSetStreamsMustBeDelegated() public {
         notDelegatedReverts().setStreams(
-            erc20, new StreamReceiver[](0), 0, new StreamReceiver[](0), 0, 0, user
+            erc20, new StreamReceiver[](0), 0, new StreamReceiver[](0), noHints, user
         );
     }
 

--- a/test/Giver.t.sol
+++ b/test/Giver.t.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
-import {AddressDriver, Drips, IERC20, StreamReceiver} from "src/AddressDriver.sol";
+import {AddressDriver} from "src/AddressDriver.sol";
+import {Drips, IERC20, MaxEndHintsImpl, StreamReceiver} from "src/Drips.sol";
 import {Address, Giver, GiversRegistry} from "src/Giver.sol";
 import {ManagedProxy} from "src/Managed.sol";
 import {
@@ -139,7 +140,12 @@ contract GiversRegistryTest is Test {
     function testGiveOverMaxBalance() public {
         erc20.approve(address(addressDriver), 15);
         addressDriver.setStreams(
-            erc20, new StreamReceiver[](0), 10, new StreamReceiver[](0), 0, 0, address(this)
+            erc20,
+            new StreamReceiver[](0),
+            10,
+            new StreamReceiver[](0),
+            MaxEndHintsImpl.create(),
+            address(this)
         );
         addressDriver.give(0, erc20, 5);
         give(drips.MAX_TOTAL_BALANCE(), drips.MAX_TOTAL_BALANCE() - 15);

--- a/test/RepoDriver.t.sol
+++ b/test/RepoDriver.t.sol
@@ -5,11 +5,13 @@ import {Caller} from "src/Caller.sol";
 import {Forge, RepoDriver} from "src/RepoDriver.sol";
 import {
     AccountMetadata,
-    StreamConfigImpl,
     Drips,
-    StreamsHistory,
+    MaxEndHints,
+    MaxEndHintsImpl,
+    SplitsReceiver,
+    StreamConfigImpl,
     StreamReceiver,
-    SplitsReceiver
+    StreamsHistory
 } from "src/Drips.sol";
 import {ManagedProxy} from "src/Managed.sol";
 import {BufferChainlink, CBORChainlink} from "chainlink/Chainlink.sol";
@@ -59,6 +61,8 @@ contract RepoDriverTest is Test {
     uint256 internal accountId1;
     uint256 internal accountId2;
     uint256 internal accountIdUser;
+
+    MaxEndHints internal immutable noHints = MaxEndHintsImpl.create();
 
     bytes internal constant ERROR_NOT_OWNER = "Caller is not the account owner";
     bytes internal constant ERROR_ALREADY_INITIALIZED = "Already initialized";
@@ -228,7 +232,7 @@ contract RepoDriverTest is Test {
                             2,
                             buffer.buf
                         )
-                        )
+                    )
                 )
             ),
             ""
@@ -575,7 +579,13 @@ contract RepoDriverTest is Test {
             StreamReceiver(accountId2, StreamConfigImpl.create(0, drips.minAmtPerSec(), 0, 0));
         uint256 balance = erc20.balanceOf(address(this));
         int128 realBalanceDelta = driver.setStreams(
-            accountId1, erc20, new StreamReceiver[](0), int128(amt), receivers, 0, 0, address(this)
+            accountId1,
+            erc20,
+            new StreamReceiver[](0),
+            int128(amt),
+            receivers,
+            noHints,
+            address(this)
         );
         assertEq(erc20.balanceOf(address(this)), balance - amt, "Invalid balance after top-up");
         assertEq(erc20.balanceOf(address(drips)), amt, "Invalid Drips balance after top-up");
@@ -587,7 +597,7 @@ contract RepoDriverTest is Test {
         // Withdraw
         balance = erc20.balanceOf(address(user));
         realBalanceDelta = driver.setStreams(
-            accountId1, erc20, receivers, -int128(amt), receivers, 0, 0, address(user)
+            accountId1, erc20, receivers, -int128(amt), receivers, noHints, address(user)
         );
         assertEq(erc20.balanceOf(address(user)), balance + amt, "Invalid balance after withdrawal");
         assertEq(erc20.balanceOf(address(drips)), 0, "Invalid Drips balance after withdrawal");
@@ -599,10 +609,12 @@ contract RepoDriverTest is Test {
     function testSetStreamsDecreasingBalanceTransfersFundsToTheProvidedAddress() public {
         uint128 amt = 5;
         StreamReceiver[] memory receivers = new StreamReceiver[](0);
-        driver.setStreams(accountId, erc20, receivers, int128(amt), receivers, 0, 0, address(this));
+        driver.setStreams(
+            accountId, erc20, receivers, int128(amt), receivers, noHints, address(this)
+        );
         address transferTo = address(1234);
         int128 realBalanceDelta = driver.setStreams(
-            accountId, erc20, receivers, -int128(amt), receivers, 0, 0, transferTo
+            accountId, erc20, receivers, -int128(amt), receivers, noHints, transferTo
         );
         assertEq(erc20.balanceOf(transferTo), amt, "Invalid balance");
         assertEq(erc20.balanceOf(address(drips)), 0, "Invalid Drips balance");
@@ -614,7 +626,7 @@ contract RepoDriverTest is Test {
     function testSetStreamsRevertsWhenNotAccountOwner() public {
         StreamReceiver[] memory noReceivers = new StreamReceiver[](0);
         vm.expectRevert(ERROR_NOT_OWNER);
-        driver.setStreams(accountIdUser, erc20, noReceivers, 0, noReceivers, 0, 0, address(this));
+        driver.setStreams(accountIdUser, erc20, noReceivers, 0, noReceivers, noHints, address(this));
     }
 
     function testSetSplits() public {
@@ -698,7 +710,7 @@ contract RepoDriverTest is Test {
 
     function testSetStreamsMustBeDelegated() public {
         notDelegatedReverts().setStreams(
-            0, erc20, new StreamReceiver[](0), 0, new StreamReceiver[](0), 0, 0, user
+            0, erc20, new StreamReceiver[](0), 0, new StreamReceiver[](0), noHints, user
         );
     }
 

--- a/test/dataStore/DripsDataProxy.t.sol
+++ b/test/dataStore/DripsDataProxy.t.sol
@@ -3,7 +3,13 @@ pragma solidity ^0.8.24;
 
 import {DripsDataProxy, DripsDataStore} from "src/dataStore/DripsDataProxy.sol";
 import {
-    Drips, StreamConfigImpl, StreamReceiver, StreamsHistory, SplitsReceiver
+    Drips,
+    MaxEndHints,
+    MaxEndHintsImpl,
+    StreamConfigImpl,
+    StreamReceiver,
+    StreamsHistory,
+    SplitsReceiver
 } from "src/Drips.sol";
 import {ManagedProxy} from "src/Managed.sol";
 import {Test} from "forge-std/Test.sol";
@@ -22,6 +28,8 @@ contract DripsDataProxyTest is Test {
 
     uint256 internal account = 1;
     uint256 internal receiver = 2;
+
+    MaxEndHints internal immutable noHints = MaxEndHintsImpl.create();
 
     function setUp() public {
         Drips dripsLogic = new Drips(10);
@@ -43,7 +51,7 @@ contract DripsDataProxyTest is Test {
         );
         erc20.transfer(address(drips), 2);
         vm.prank(driver);
-        drips.setStreams(account, erc20, new StreamReceiver[](0), 2, streams, 0, 0);
+        drips.setStreams(account, erc20, new StreamReceiver[](0), 2, streams, noHints);
 
         // Create history
         (,, uint32 updateTime,, uint32 maxEnd) = drips.streamsState(account, erc20);
@@ -102,7 +110,7 @@ contract DripsDataProxyTest is Test {
         dripsDataStore.storeStreams(streams);
         erc20.transfer(address(drips), 2);
         vm.prank(driver);
-        drips.setStreams(account, erc20, new StreamReceiver[](0), 2, streams, 0, 0);
+        drips.setStreams(account, erc20, new StreamReceiver[](0), 2, streams, noHints);
 
         uint256 balanceAt = dataProxy.balanceAt(account, erc20, uint32(vm.getBlockTimestamp() + 1));
         assertEq(balanceAt, 1, "Invalid balance");

--- a/test/dataStore/RepoDriverDataProxy.t.sol
+++ b/test/dataStore/RepoDriverDataProxy.t.sol
@@ -6,7 +6,13 @@ import {
 } from "src/dataStore/RepoDriverDataProxy.sol";
 import {Call, Caller} from "src/Caller.sol";
 import {
-    AccountMetadata, StreamConfigImpl, Drips, StreamReceiver, SplitsReceiver
+    AccountMetadata,
+    MaxEndHints,
+    MaxEndHintsImpl,
+    StreamConfigImpl,
+    Drips,
+    StreamReceiver,
+    SplitsReceiver
 } from "src/Drips.sol";
 import {ManagedProxy} from "src/Managed.sol";
 import {Forge} from "src/RepoDriver.sol";
@@ -34,6 +40,8 @@ contract RepoDriverDataProxyTest is Test {
 
     address internal user = address(1);
     uint256 internal accountId;
+
+    MaxEndHints internal immutable noHints = MaxEndHintsImpl.create();
 
     function setUp() public {
         Drips dripsLogic = new Drips(10);
@@ -80,7 +88,7 @@ contract RepoDriverDataProxyTest is Test {
         uint256 balance = erc20.balanceOf(address(this));
 
         int128 balanceDelta =
-            dataProxy.setStreams(accountId, erc20, int128(amt), hash, 0, 0, address(this));
+            dataProxy.setStreams(accountId, erc20, int128(amt), hash, noHints, address(this));
 
         assertEq(erc20.balanceOf(address(this)), balance - amt, "Invalid balance after top-up");
         assertEq(erc20.balanceOf(address(drips)), amt, "Invalid Drips balance after top-up");
@@ -92,7 +100,8 @@ contract RepoDriverDataProxyTest is Test {
         // Withdraw
         balance = erc20.balanceOf(address(user));
 
-        balanceDelta = dataProxy.setStreams(accountId, erc20, -int128(amt), 0, 0, 0, address(user));
+        balanceDelta =
+            dataProxy.setStreams(accountId, erc20, -int128(amt), 0, noHints, address(user));
 
         assertEq(erc20.balanceOf(address(user)), balance + amt, "Invalid balance after withdrawal");
         assertEq(erc20.balanceOf(address(drips)), 0, "Invalid Drips balance after withdrawal");
@@ -109,8 +118,8 @@ contract RepoDriverDataProxyTest is Test {
         calls[0] = Call({
             target: address(dataProxy),
             data: abi.encodeCall(
-                dataProxy.setStreams, (accountId, erc20, int128(amt), 0, 0, 0, address(this))
-                ),
+                dataProxy.setStreams, (accountId, erc20, int128(amt), 0, noHints, address(this))
+            ),
             value: 0
         });
 
@@ -174,7 +183,7 @@ contract RepoDriverDataProxyTest is Test {
     }
 
     function testSetStreamsMustBeDelegated() public {
-        notDelegatedReverts().setStreams(0, erc20, 0, 0, 0, 0, user);
+        notDelegatedReverts().setStreams(0, erc20, 0, 0, noHints, user);
     }
 
     function testSetSplitsMustBeDelegated() public {


### PR DESCRIPTION
This makes the calldata simpler by replacing zero-padded 4-byte words with a full word. The API also becomes cleaner by reducing the number of parameters.